### PR TITLE
Remove title animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,9 +166,7 @@
   <div class="container pb-16">
     <div class="row">
       <div class="col-12">
-        <div class="typewriter">
-          <h1>MIT Bitcoin Expo 2022</h1>
-        </div>
+          <h1 class="title">MIT Bitcoin Expo 2022</h1>
         
         <div class="content">
           


### PR DESCRIPTION
This PR is intended to remove the animation that was in place for the title 'MIT Bitcoin Expo 2022'.

(See screenshot for the fixed title)
<img width="1382" alt="Screen Shot 2021-11-09 at 6 35 36 AM" src="https://user-images.githubusercontent.com/46166436/140917396-3f07309a-6b39-4c1c-821a-bb8ae7d3bafb.png">


